### PR TITLE
Gulpfile.coffee support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -134,7 +134,7 @@ echo "export PATH=\"\$HOME/vendor/node/bin:\$HOME/bin:\$HOME/node_modules/.bin:\
 
 # Check and run gulp
 (
-  if [ -f $build_dir/gulpfile.js ]; then
+  if [ -f $build_dir/gulpfile.js ] || [ -f $build_dir/gulpfile.coffee ]; then
     # get the env vars
     if [ -d "$env_dir" ]; then
       status "Exporting config vars to environment"
@@ -143,6 +143,11 @@ echo "export PATH=\"\$HOME/vendor/node/bin:\$HOME/bin:\$HOME/node_modules/.bin:\
 
     # Install gulp locally
     npm install gulp
+
+    if [ -f $build_dir/gulpfile.coffee ]; then
+      echo "-----> Detected coffeescript gulpfile"
+      npm install coffee-script
+    fi 
     echo "-----> Found gulpfile, running gulp heroku:$NODE_ENV task"
     $build_dir/node_modules/.bin/gulp heroku:$NODE_ENV
   else


### PR DESCRIPTION
Added support for coffee-script gulpfiles.

Note: Not sure if this was on purpose but the check was/is looking for 'gulpfile.js/coffee' with a lowercase g. I get the feeling Gulpfiles and Gruntfiles tend to have an uppercase G. I had to rename mine to lowercase to get it working on heroku.

Nice job btw :)